### PR TITLE
Fix for gnome extension "no title bar".

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -130,7 +130,8 @@ blacklist ${RUNUSER}/kdesud_*
 
 # gnome
 # contains extensions, last used times of applications, and notifications
-blacklist ${HOME}/.local/share/gnome-shell
+read-only ${HOME}/.local/share/gnome-shell
+blacklist ${HOME}/.local/share/gnome-shell/application_state
 
 # systemd
 blacklist ${HOME}/.config/systemd


### PR DESCRIPTION
Gnome extension "no title bar" under Wayland will not work if we blacklist gnome-shell user directory. By make extension directory "read-only" and whitelist it will solve the problem.